### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then, require the package and use it like so:
     let ThermalPrinterEncoder = require('thermal-printer-encoder');
 
     let encoder = new ThermalPrinterEncoder({
-        language: 'esc/pos'
+        language: 'esc-pos'
     });
 
     let result = encoder


### PR DESCRIPTION
Closes #1

Fix discrepancy in readme:

README:
https://github.com/NielsLeenheer/ThermalPrinterEncoder/blob/389e1ec08a0dece532a33c9d217d345c9c8a074f/README.md?plain=1#L15-L17

Library:
https://github.com/NielsLeenheer/ThermalPrinterEncoder/blob/389e1ec08a0dece532a33c9d217d345c9c8a074f/src/thermal-printer-encoder.js#L14-L17